### PR TITLE
Add non_exhaustive to the main enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use ::std::env;
 
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DesktopEnvironment {
   Unknown,
   Cinnamon,


### PR DESCRIPTION
This allows future variants to be added without incurring a breaking change.