### PR TITLE
Detect `ubuntu:GNOME` as Gnome

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ impl DesktopEnvironment {
         "Unity" => Some(DesktopEnvironment::Unity),
         "X-Cinnamon" => Some(DesktopEnvironment::Cinnamon),
         "XFCE" => Some(DesktopEnvironment::Xfce),
+        "ubuntu:GNOME" => Some(DesktopEnvironment::Gnome),
         _ => None,
       })
   }


### PR DESCRIPTION
On Ubuntu 20.04 `$XDG_CURRENT_DESKTOP` is set to `ubuntu:GNOME`. This change will make `ubuntu:GNOME` be detected as a Gnome desktop environment.