### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 1.1.0 (2024-04-16)
 
 - **[Feature]** Detect more environments: Deepin DE, EDE, Endless OS, Hyprland, Old (legacy menus), Pantheon (Elementary OS), Razor, ROX, Sway, Trinity DE ([@nagua](https://github.com/nagua), [#6](https://github.com/demurgos/detect-desktop-environment/pull/6))
 - **[Fix]** Fix parsing of `XDG_CURERNT_DESKTOP` ([@nagua](https://github.com/nagua), [#6](https://github.com/demurgos/detect-desktop-environment/pull/6))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "detect-desktop-environment"
-version = "1.0.0"
+version = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "detect-desktop-environment"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Autodetect the desktop environment"
 documentation = "https://docs.rs/detect-desktop-environment/latest/detect_desktop_environment/"


### PR DESCRIPTION
- **[Feature]** Detect more environments: Deepin DE, EDE, Endless OS, Hyprland, Old (legacy menus), Pantheon (Elementary OS), Razor, ROX, Sway, Trinity DE ([@nagua](https://github.com/nagua), [#6](https://github.com/demurgos/detect-desktop-environment/pull/6))
- **[Fix]** Fix parsing of `XDG_CURERNT_DESKTOP` ([@nagua](https://github.com/nagua), [#6](https://github.com/demurgos/detect-desktop-environment/pull/6))