### PR TITLE
Exclude `thumbnails` folder from package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - **[Fix]** Fix spelling when matching `GNOME-Classic`. ([@bash](https://github.com/bash), [#11](https://github.com/demurgos/detect-desktop-environment/pull/11))
+- **[Fix]** Remove thumbnails from Cargo package, for faster downloads. ([@bbb651](https://github.com/bbb651), [#12](https://github.com/demurgos/detect-desktop-environment/pull/12))
 
 # 1.1.0 (2024-04-16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["desktop-environment", "detect", "env"]
 categories = ["gui", "os"]
 license = "MIT"
 edition = "2021"
+exclude = ["thumbnails"]
 # Rust support policy:
 # - The 8 last stable versions are supported (1 year)
 # - Other versions are supported on a best-effort basis


### PR DESCRIPTION
This reduces the folder significantly, by 1.4MB (~90% reduction). Thankfully crates.io makes links in the README relative to the repository (e.g. `https://github.com/demurgos/detect-desktop-environment/raw/HEAD/././thumbnails/cinnamon.png`) so it shouldn't break it.

Maybe `CHANGELOG.md` should be excluded too, I've seen some other projects do so (e.g. Tauri), but it's small enough that it's probably fine to keep it there.